### PR TITLE
nogc compatibility for encoder / decoder

### DIFF
--- a/source/hpack/decoder.d
+++ b/source/hpack/decoder.d
@@ -5,10 +5,10 @@ import hpack.huffman;
 import hpack.tables;
 import hpack.util;
 
+import vibe.internal.array : BatchBuffer;
+
 import std.range; // Decoder
 import std.string : representation;
-import std.array;
-import std.typecons : tuple;
 
 /** Module to implement an header decoder consistent with HPACK specifications (RFC 7541)
   * The detailed description of the decoding process, examples and binary format details can
@@ -19,239 +19,104 @@ import std.typecons : tuple;
 */
 alias HTTP2SettingValue = uint;
 
-/** implements an input range to decode an header block
-  * m_table is a reference to the original table
-  */
-struct HeaderDecoder(T = ubyte[])
-		if (isInputRange!T && (is(ElementType!T : char) || (is(ElementType!T : ubyte))))
+void decode(I, R)(ref I src, ref R dst, ref IndexingTable table) @safe
 {
-	private {
-		immutable(ubyte)[] m_range;
-		IndexingTable m_table; // only for retrieving data
-		HTTP2HeaderTableField m_decoded;
-	}
+	ubyte bbuf = src[0];
+	src = src[1..$];
 
-	this(T range, IndexingTable table) @trusted
-	{
-		static if(is(typeof(representation(range)) == immutable(ubyte)[])) m_range = range;
-		else m_range = cast(immutable(ubyte)[])range;
+	if(bbuf & 128) {
+		auto res = decodeInteger(src, bbuf);
+		dst.put(table[res]);
+	} else {
+		HTTP2HeaderTableField hres;
+		bool update = false;
 
-		m_table = table;
-
-		decode();
-	}
-
-// InputRange specific methods
-	@property bool empty() @safe @nogc { return m_range.empty; }
-
-	@property auto front() @safe @nogc { return m_decoded; }
-
-	void popFront() @safe
-	{
-		assert(!empty, "Cannot call popFront on an empty HeaderDecoder");
-
-		// advance if data is still available
-		decode();
-	}
-
-	void put(T)(T range) @trusted
-	{
-		static if(is(typeof(representation(range)) == immutable(ubyte)[])) m_range = range;
-		else m_range ~= cast(immutable(ubyte)[])range;
-
-		decode();
-	}
-
-	@property bool toIndex() @safe @nogc { return m_decoded.index; }
-
-	@property bool neverIndexed() @safe @nogc { return m_decoded.neverIndex; }
-
-// decoding
-	private {
-
-		void decode() @safe
-		{
-			ubyte bbuf = m_range[0];
-			m_range = m_range[1..$];
-
-			if(bbuf & 128) {
-				auto res = decodeInteger(bbuf);
-				m_decoded = m_table[res];
-			} else {
-				HTTP2HeaderTableField hres;
-				bool update = false;
-
-				if (bbuf & 64) { // inserted in dynamic table
-					auto idx = bbuf.toInteger(2);
-					if(idx > 0) {  // name == table[index].name, value == literal
-						hres.name = m_table[idx].name;
-					} else {   // name == literal, value == literal
-						hres.name = decodeLiteral();
-					}
-					hres.value = decodeLiteral();
-					hres.index = true;
-					hres.neverIndex = false;
-
-				} else if(bbuf & 16) { // NEVER inserted in dynamic table
-					auto idx = bbuf.toInteger(4);
-					if(idx > 0) {  // name == table[index].name, value == literal
-						hres.name = m_table[idx].name;
-					} else {   // name == literal, value == literal
-						hres.name = decodeLiteral();
-					}
-					hres.value = decodeLiteral();
-					hres.index = false;
-					hres.neverIndex = true;
-
-				} else if(!(bbuf & 32)) { // this occourrence is not inserted in dynamic table
-					auto idx = bbuf.toInteger(4);
-					if(idx > 0) {  // name == table[index].name, value == literal
-						hres.name = m_table[idx].name;
-					} else {   // name == literal, value == literal
-						hres.name = decodeLiteral();
-					}
-					hres.value = decodeLiteral();
-					hres.index = hres.neverIndex = false;
-
-				} else { // dynamic table size update (bbuf[2] is set)
-					update = true;
-					auto nsize = bbuf.toInteger(3);
-					m_table.updateSize(cast(HTTP2SettingValue)nsize);
-				}
-				assert(!(hres.index && hres.neverIndex), "Invalid header indexing information");
-
-				if(!update) m_decoded = hres;
+		if (bbuf & 64) { // inserted in dynamic table
+			auto idx = bbuf.toInteger(2);
+			if(idx > 0) {  // name == table[index].name, value == literal
+				hres.name = table[idx].name;
+			} else {   // name == literal, value == literal
+				decodeLiteral(src, hres.name);
 			}
-		}
+			decodeLiteral(src, hres.value);
+			hres.index = true;
+			hres.neverIndex = false;
 
-		size_t decodeInteger(ubyte bbuf) @safe @nogc
-		{
-			uint nbits = 7;
-			auto res = bbuf.toInteger(1);
-
-			if (res < (1 << nbits) - 1) {
-				return res;
-			} else {
-				uint m = 0;
-				do {
-					// take another octet
-					bbuf = m_range[0];
-					m_range = m_range[1..$];
-					// concatenate it to the result
-					res = res + bbuf.toInteger(1)*(1 << m);
-					m += 7;
-				} while(bbuf == 1);
-				return res;
+		} else if(bbuf & 16) { // NEVER inserted in dynamic table
+			auto idx = bbuf.toInteger(4);
+			if(idx > 0) {  // name == table[index].name, value == literal
+				hres.name = table[idx].name;
+			} else {   // name == literal, value == literal
+				decodeLiteral(src, hres.name);
 			}
-		}
+			decodeLiteral(src, hres.value);
+			hres.index = false;
+			hres.neverIndex = true;
 
-		string decodeLiteral() @safe
-		{
-			ubyte bbuf = m_range[0];
-			m_range = m_range[1..$];
-
-			auto res = appender!string; // TODO a proper allocator
-			bool huffman = (bbuf & 128) ? true : false;
-
-
-			assert(!m_range.empty, "Cannot decode from empty range block");
-
-			// take a buffer of remaining octets
-			auto vlen = bbuf.toInteger(1); // value length
-			auto buf = m_range[0..vlen];
-			m_range = m_range[vlen..$];
-
-			if(huffman) { // huffman encoded
-				decodeHuffman(buf, res);
-			} else { // raw encoded
-				res.put(buf);
+		} else if(!(bbuf & 32)) { // this occourrence is not inserted in dynamic table
+			auto idx = bbuf.toInteger(4);
+			if(idx > 0) {  // name == table[index].name, value == literal
+				hres.name = table[idx].name;
+			} else {   // name == literal, value == literal
+				decodeLiteral(src, hres.name);
 			}
-			return res.data;
+			decodeLiteral(src, hres.value);
+			hres.index = hres.neverIndex = false;
+
+		} else { // dynamic table size update (bbuf[2] is set)
+			update = true;
+			auto nsize = bbuf.toInteger(3);
+			table.updateSize(cast(HTTP2SettingValue)nsize);
 		}
+		assert(!(hres.index && hres.neverIndex), "Invalid header indexing information");
+
+		if(!update) dst.put(hres);
 	}
 }
 
-unittest {
-	// Following examples can be found in Appendix C of the HPACK RFC
+private size_t decodeInteger(I)(ref I src, ubyte bbuf) @safe @nogc
+{
+	uint nbits = 7;
+	auto res = bbuf.toInteger(1);
 
-	IndexingTable table = IndexingTable(4096);
-	/** 1. Literal header field w. indexing (raw)
-	  * custom-key: custom-header
-	  */
-	ubyte[] block = [0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79,
-		0x0d, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72];
-
-	auto decoder = HeaderDecoder!(ubyte[])(block, table);
-	assert(decoder.front.name == "custom-key" && decoder.front.value == "custom-header");
-	// check entries to be inserted in the indexing table (dynamic)
-	assert(decoder.front.index);
-
-	/** 1bis. Literal header field w. indexing (huffman encoded)
-	  * :authority: www.example.com
-	  */
-	block = [0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff];
-	decoder.put(block);
-	assert(decoder.front.name == ":authority" && decoder.front.value == "www.example.com");
-	assert(decoder.front.index);
-
-	/** 2. Literal header field without indexing (raw)
-	  * :path: /sample/path
-	  */
-	block = [0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68];
-	decoder.put(block);
-	assert(decoder.front.name == ":path" && decoder.front.value == "/sample/path");
-
-
-	/** 3. Literal header field never indexed (raw)
-	  * password: secret
-	  */
-	block = [0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06, 0x73, 0x65,
-		  0x63, 0x72, 0x65, 0x74];
-	decoder.put(block);
-	assert(decoder.front.name == "password" && decoder.front.value == "secret");
-	assert(decoder.front.neverIndex);
-
-
-	/** 4. Indexed header field (integer)
-	  * :method: GET
-	  */
-	import vibe.http.common;
-	block = [0x82];
-	decoder.put(block);
-	assert(decoder.front.name == ":method" && decoder.front.value == HTTPMethod.GET);
-
-	/** 5. Full request without huffman encoding
-	  * :method: GET
-      * :scheme: http
-      * :path: /
-      * :authority: www.example.com
-      * cache-control: no-cache
-	  */
-	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63, 0x61, 0x63, 0x68, 0x65];
-	table.insert(HTTP2HeaderTableField(":authority", "www.example.com"));
-	auto rdec = HeaderDecoder!(ubyte[])(block, table);
-	HTTP2HeaderTableField[] expected = [
-		HTTP2HeaderTableField(":method", HTTPMethod.GET),
-		HTTP2HeaderTableField(":scheme", "http"),
-		HTTP2HeaderTableField(":path", "/"),
-		HTTP2HeaderTableField(":authority", "www.example.com"),
-		HTTP2HeaderTableField("cache-control", "no-cache")];
-
-	foreach(i,h; rdec.enumerate(0)) {
-		assert(h == expected[i]);
-	}
-
-	/** 5. Full request with huffman encoding
-	  * :method: GET
-      * :scheme: http
-      * :path: /
-      * :authority: www.example.com
-      * cache-control: no-cache
-	  */
-	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c,0xbf];
-	auto hdec = HeaderDecoder!(ubyte[])(block, table);
-
-	foreach(i,h; hdec.enumerate(0)) {
-		assert(h == expected[i]);
+	if (res < (1 << nbits) - 1) {
+		return res;
+	} else {
+		uint m = 0;
+		do {
+			// take another octet
+			bbuf = src[0];
+			src = src[1..$];
+			// concatenate it to the result
+			res = res + bbuf.toInteger(1)*(1 << m);
+			m += 7;
+		} while(bbuf == 1);
+		return res;
 	}
 }
+
+private string decodeLiteral(I,R)(ref I src, ref R dst) @safe
+{
+	ubyte bbuf = src[0];
+	src = src[1..$];
+
+	bool huffman = (bbuf & 128) ? true : false;
+
+
+	assert(!src.empty, "Cannot decode from empty range block");
+
+	// take a buffer of remaining octets
+	auto vlen = bbuf.toInteger(1); // value length
+	auto buf = src[0..vlen];
+	src = src[vlen..$];
+
+	if(huffman) { // huffman encoded
+		BatchBuffer!(immutable(char), 0) adst;
+		adst.putN(vlen);
+		decodeHuffman(buf, adst);
+		dst = cast(string)adst.peekDst;
+	} else { // raw encoded
+		dst = buf;
+	}
+}
+

--- a/source/hpack/decoder.d
+++ b/source/hpack/decoder.d
@@ -102,7 +102,6 @@ private void decodeLiteral(I,R)(ref I src, ref R dst) @safe
 
 	bool huffman = (bbuf & 128) ? true : false;
 
-	auto adst = appender!(immutable(char)[]); // TODO a proper allocator
 	assert(!src.empty, "Cannot decode from empty range block");
 
 	// take a buffer of remaining octets
@@ -111,6 +110,8 @@ private void decodeLiteral(I,R)(ref I src, ref R dst) @safe
 	src = src[vlen..$];
 
 	if(huffman) { // huffman encoded
+		auto adst = appender!string; // TODO a proper allocator
+		adst.reserve(vlen*2); // max compression ratio is < 0.5
 		decodeHuffman(buf, adst);
 		dst = adst.data;
 	} else { // raw encoded

--- a/source/hpack/hpack.d
+++ b/source/hpack/hpack.d
@@ -10,8 +10,8 @@ import std.typecons;
 import std.array; // appender
 import std.algorithm.iteration;
 
-void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = true)
-@safe
+void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = true) @safe
+	if(is(I == HTTP2HeaderTableField) || is(ElementType!I : HTTP2HeaderTableField))
 {
 	static if(is(I == HTTP2HeaderTableField)) {
 		src.encode(dst, table, huffman);
@@ -87,7 +87,6 @@ unittest {
       * :authority: www.example.com
       * cache-control: no-cache
 	  */
-	import vibe.internal.array : BatchBuffer;
 	HTTP2HeaderTableField[] block = [
 		HTTP2HeaderTableField(":method", HTTPMethod.GET),
 		HTTP2HeaderTableField(":scheme", "http"),
@@ -113,3 +112,4 @@ unittest {
 	block.encodeHPACK(bbres, table, true);
 	assert(bbres.data == eexpected);
 }
+

--- a/source/hpack/hpack.d
+++ b/source/hpack/hpack.d
@@ -5,10 +5,12 @@ import hpack.encoder;
 import hpack.decoder;
 import hpack.tables;
 
+
 import std.range;
 import std.typecons;
 import std.array; // appender
 import std.algorithm.iteration;
+
 
 void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = true) @safe
 	if(is(I == HTTP2HeaderTableField) || is(ElementType!I : HTTP2HeaderTableField))
@@ -20,19 +22,23 @@ void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = 
 	}
 }
 
-void decodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table) @safe
+void decodeHPACK(I,R,T)(I src, ref R dst, ref IndexingTable table, ref T alloc) @safe
 	if(isInputRange!I && (is(ElementType!I : immutable(ubyte)) || is(ElementType!I : immutable(char))))
 {
-	while(!src.empty) src.decode(dst, table);
+	while(!src.empty) src.decode(dst, table, alloc);
 }
 
 /// ENCODER
 unittest {
-	// Following examples can be found in Appendix C of the HPACK RFC
+	//// Following examples can be found in Appendix C of the HPACK RFC
 	import vibe.http.status;
 	import vibe.http.common;
+	import vibe.internal.utilallocator: RegionListAllocator;
+	import std.experimental.allocator;
+	import std.experimental.allocator.gc_allocator;
 
 	IndexingTable table = IndexingTable(4096);
+	scope alloc = new RegionListAllocator!(shared(GCAllocator), false)(1024, GCAllocator.instance);
 
 	/** 1. Literal header field w. indexing (raw)
 	  * custom-key: custom-header
@@ -42,7 +48,8 @@ unittest {
 	auto dec1 = appender!(HTTP2HeaderTableField[]);
 
 	h1.encodeHPACK(e1, table, false);
-	decodeHPACK(cast(immutable(ubyte)[])e1.data, dec1, table);
+	decodeHPACK(cast(immutable(ubyte)[])e1.data, dec1, table, alloc);
+	import std.stdio;
 	assert(dec1.data.front == h1);
 
 	/** 1bis. Literal header field w. indexing (huffman encoded)
@@ -56,7 +63,7 @@ unittest {
 	auto dec1b = appender!(HTTP2HeaderTableField[]);
 
 	h1b.encodeHPACK(e1b, table, true);
-	decodeHPACK(cast(immutable(ubyte)[])e1b.data, dec1b, table);
+	decodeHPACK(cast(immutable(ubyte)[])e1b.data, dec1b, table, alloc);
 	assert(dec1b.data.front == h1b);
 
 	/** 2. Literal header field without indexing (raw)
@@ -70,7 +77,7 @@ unittest {
 	auto dec2 = appender!(HTTP2HeaderTableField[]);
 
 	h2.encodeHPACK(e2, table, false);
-	decodeHPACK(cast(immutable(ubyte)[])e2.data, dec2, table);
+	decodeHPACK(cast(immutable(ubyte)[])e2.data, dec2, table, alloc);
 	assert(dec2.data.front == h2);
 
 	/** 3. Literal header field never indexed (raw)
@@ -83,7 +90,7 @@ unittest {
 	auto dec3 = appender!(HTTP2HeaderTableField[]);
 
 	h3.encodeHPACK(e3, table, false);
-	decodeHPACK(cast(immutable(ubyte)[])e3.data, dec3, table);
+	decodeHPACK(cast(immutable(ubyte)[])e3.data, dec3, table, alloc);
 	assert(dec3.data.front == h3);
 
 	/** 4. Indexed header field (integer)
@@ -94,7 +101,7 @@ unittest {
 	auto dec4 = appender!(HTTP2HeaderTableField[]);
 
 	h4.encodeHPACK(e4, table);
-	decodeHPACK(cast(immutable(ubyte)[])e4.data, dec4, table);
+	decodeHPACK(cast(immutable(ubyte)[])e4.data, dec4, table, alloc);
 	assert(dec4.data.front == h4);
 
 	/** 5. Full request without huffman encoding
@@ -132,9 +139,15 @@ unittest {
 
 /// DECODER
 unittest {
-	// Following examples can be found in Appendix C of the HPACK RFC
+	//// Following examples can be found in Appendix C of the HPACK RFC
+
+	import vibe.internal.utilallocator: RegionListAllocator;
+	import std.experimental.allocator;
+	import std.experimental.allocator.gc_allocator;
 
 	IndexingTable table = IndexingTable(4096);
+	scope alloc = new RegionListAllocator!(shared(GCAllocator), false)(1024, GCAllocator.instance);
+
 	/** 1. Literal header field w. indexing (raw)
 	  * custom-key: custom-header
 	  */
@@ -143,7 +156,7 @@ unittest {
 
 	//auto decoder = HeaderDecoder!(ubyte[])(block, table);
 	auto dec1 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(dec1, table);
+	block.decodeHPACK(dec1, table, alloc);
 	assert(dec1.data.front.name == "custom-key" && dec1.data.front.value == "custom-header");
 	// check entries to be inserted in the indexing table (dynamic)
 	assert(dec1.data.front.index);
@@ -153,7 +166,7 @@ unittest {
 	  */
 	block = [0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff];
 	auto dec1b = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(dec1b, table);
+	block.decodeHPACK(dec1b, table, alloc);
 	assert(dec1b.data.front.name == ":authority" && dec1b.data.front.value == "www.example.com");
 	assert(dec1b.data.front.index);
 
@@ -162,7 +175,7 @@ unittest {
 	  */
 	block = [0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68];
 	auto dec2 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(dec2, table);
+	block.decodeHPACK(dec2, table, alloc);
 	assert(dec2.data.front.name == ":path" && dec2.data.front.value == "/sample/path");
 
 
@@ -172,7 +185,7 @@ unittest {
 	block = [0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06, 0x73, 0x65,
 		  0x63, 0x72, 0x65, 0x74];
 	auto dec3 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(dec3, table);
+	block.decodeHPACK(dec3, table, alloc);
 	assert(dec3.data.front.name == "password" && dec3.data.front.value == "secret");
 	assert(dec3.data.front.neverIndex);
 
@@ -183,7 +196,7 @@ unittest {
 	import vibe.http.common;
 	block = [0x82];
 	auto dec4 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(dec4, table);
+	block.decodeHPACK(dec4, table, alloc);
 	assert(dec4.data.front.name == ":method" && dec4.data.front.value == HTTPMethod.GET);
 
 	/** 5. Full request without huffman encoding
@@ -196,7 +209,7 @@ unittest {
 	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63, 0x61, 0x63, 0x68, 0x65];
 	table.insert(HTTP2HeaderTableField(":authority", "www.example.com"));
 	auto decR1 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(decR1, table);
+	block.decodeHPACK(decR1, table, alloc);
 	HTTP2HeaderTableField[] expected = [
 		HTTP2HeaderTableField(":method", HTTPMethod.GET),
 		HTTP2HeaderTableField(":scheme", "http"),
@@ -217,9 +230,29 @@ unittest {
 	  */
 	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c,0xbf];
 	auto decR2 = appender!(HTTP2HeaderTableField[]);
-	block.decodeHPACK(decR2, table);
+	block.decodeHPACK(decR2, table, alloc);
 
 	foreach(i,h; decR2.data.enumerate(0)) {
 		assert(h == expected[i]);
 	}
+}
+
+
+/// Mallocator
+unittest {
+	import vibe.internal.utilallocator: RegionListAllocator;
+	import std.experimental.allocator;
+	import std.experimental.allocator.mallocator;
+	import std.experimental.allocator.gc_allocator;
+	auto table = IndexingTable(4096);
+	/** 1bis. Literal header field w. indexing (huffman encoded)
+	  * :authority: www.example.com
+	  */
+	immutable(ubyte)[] block = [0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff];
+	scope alloc = new RegionListAllocator!(shared(Mallocator), false)(1024, Mallocator.instance);
+
+	auto dec1b = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec1b, table, alloc);
+	assert(dec1b.data.front.name == ":authority" && dec1b.data.front.value == "www.example.com");
+	assert(dec1b.data.front.index);
 }

--- a/source/hpack/hpack.d
+++ b/source/hpack/hpack.d
@@ -49,7 +49,6 @@ unittest {
 
 	h1.encodeHPACK(e1, table, false);
 	decodeHPACK(cast(immutable(ubyte)[])e1.data, dec1, table, alloc);
-	import std.stdio;
 	assert(dec1.data.front == h1);
 
 	/** 1bis. Literal header field w. indexing (huffman encoded)

--- a/source/hpack/hpack.d
+++ b/source/hpack/hpack.d
@@ -20,6 +20,13 @@ void encodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table, bool huffman = 
 	}
 }
 
+void decodeHPACK(I,R)(I src, ref R dst, ref IndexingTable table) @safe
+	if(isInputRange!I && (is(ElementType!I : immutable(ubyte)) || is(ElementType!I : immutable(char))))
+{
+	while(!src.empty) src.decode(dst, table);
+}
+
+/// ENCODER
 unittest {
 	// Following examples can be found in Appendix C of the HPACK RFC
 	import vibe.http.status;
@@ -32,9 +39,11 @@ unittest {
 	  */
 	HTTP2HeaderTableField h1 = HTTP2HeaderTableField("custom-key", "custom-header");
 	auto e1 = appender!(ubyte[]);
+	auto dec1 = appender!(HTTP2HeaderTableField[]);
+
 	h1.encodeHPACK(e1, table, false);
-	auto d1 = HeaderDecoder!(ubyte[])(e1.data, table);
-	assert(d1.front == h1);
+	decodeHPACK(cast(immutable(ubyte)[])e1.data, dec1, table);
+	assert(dec1.data.front == h1);
 
 	/** 1bis. Literal header field w. indexing (huffman encoded)
 	  * :authority: www.example.com
@@ -44,21 +53,25 @@ unittest {
 	h1b.neverIndex = false;
 	h1b.index = true;
 	auto e1b = appender!(ubyte[]);
+	auto dec1b = appender!(HTTP2HeaderTableField[]);
+
 	h1b.encodeHPACK(e1b, table, true);
-	auto d1b = HeaderDecoder!(ubyte[])(e1b.data, table);
-	assert(d1b.front == h1b);
+	decodeHPACK(cast(immutable(ubyte)[])e1b.data, dec1b, table);
+	assert(dec1b.data.front == h1b);
 
 	/** 2. Literal header field without indexing (raw)
 	  * :path: /sample/path
 	  */
-	HTTP2HeaderTableField h2 = HTTP2HeaderTableField(":path", "/sample/path");
+	auto h2 = HTTP2HeaderTableField(":path", "/sample/path");
 	h2.neverIndex = false;
 	h2.index = false;
 	// initialize with huffman=false (can be modified by e2.huffman)
 	auto e2 = appender!(ubyte[]);
+	auto dec2 = appender!(HTTP2HeaderTableField[]);
+
 	h2.encodeHPACK(e2, table, false);
-	auto d2 = HeaderDecoder!(ubyte[])(e2.data, table);
-	assert(d2.front == h2);
+	decodeHPACK(cast(immutable(ubyte)[])e2.data, dec2, table);
+	assert(dec2.data.front == h2);
 
 	/** 3. Literal header field never indexed (raw)
 	  * password: secret
@@ -67,18 +80,22 @@ unittest {
 	h3.neverIndex = true;
 	h3.index = false;
 	auto e3 = appender!(ubyte[]);
+	auto dec3 = appender!(HTTP2HeaderTableField[]);
+
 	h3.encodeHPACK(e3, table, false);
-	auto d3 = HeaderDecoder!(ubyte[])(e3.data, table);
-	assert(d3.front == h3);
+	decodeHPACK(cast(immutable(ubyte)[])e3.data, dec3, table);
+	assert(dec3.data.front == h3);
 
 	/** 4. Indexed header field (integer)
 	  * :method: GET
 	  */
 	HTTP2HeaderTableField h4 = HTTP2HeaderTableField(":method", HTTPMethod.GET);
 	auto e4 = appender!(ubyte[]);
+	auto dec4 = appender!(HTTP2HeaderTableField[]);
+
 	h4.encodeHPACK(e4, table);
-	auto d4 = HeaderDecoder!(ubyte[])(e4.data, table);
-	assert(d4.front == h4);
+	decodeHPACK(cast(immutable(ubyte)[])e4.data, dec4, table);
+	assert(dec4.data.front == h4);
 
 	/** 5. Full request without huffman encoding
 	  * :method: GET
@@ -113,3 +130,96 @@ unittest {
 	assert(bbres.data == eexpected);
 }
 
+/// DECODER
+unittest {
+	// Following examples can be found in Appendix C of the HPACK RFC
+
+	IndexingTable table = IndexingTable(4096);
+	/** 1. Literal header field w. indexing (raw)
+	  * custom-key: custom-header
+	  */
+	immutable(ubyte)[] block = [0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79,
+		0x0d, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72];
+
+	//auto decoder = HeaderDecoder!(ubyte[])(block, table);
+	auto dec1 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec1, table);
+	assert(dec1.data.front.name == "custom-key" && dec1.data.front.value == "custom-header");
+	// check entries to be inserted in the indexing table (dynamic)
+	assert(dec1.data.front.index);
+
+	/** 1bis. Literal header field w. indexing (huffman encoded)
+	  * :authority: www.example.com
+	  */
+	block = [0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff];
+	auto dec1b = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec1b, table);
+	assert(dec1b.data.front.name == ":authority" && dec1b.data.front.value == "www.example.com");
+	assert(dec1b.data.front.index);
+
+	/** 2. Literal header field without indexing (raw)
+	  * :path: /sample/path
+	  */
+	block = [0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68];
+	auto dec2 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec2, table);
+	assert(dec2.data.front.name == ":path" && dec2.data.front.value == "/sample/path");
+
+
+	/** 3. Literal header field never indexed (raw)
+	  * password: secret
+	  */
+	block = [0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06, 0x73, 0x65,
+		  0x63, 0x72, 0x65, 0x74];
+	auto dec3 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec3, table);
+	assert(dec3.data.front.name == "password" && dec3.data.front.value == "secret");
+	assert(dec3.data.front.neverIndex);
+
+
+	/** 4. Indexed header field (integer)
+	  * :method: GET
+	  */
+	import vibe.http.common;
+	block = [0x82];
+	auto dec4 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(dec4, table);
+	assert(dec4.data.front.name == ":method" && dec4.data.front.value == HTTPMethod.GET);
+
+	/** 5. Full request without huffman encoding
+	  * :method: GET
+      * :scheme: http
+      * :path: /
+      * :authority: www.example.com
+      * cache-control: no-cache
+	  */
+	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63, 0x61, 0x63, 0x68, 0x65];
+	table.insert(HTTP2HeaderTableField(":authority", "www.example.com"));
+	auto decR1 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(decR1, table);
+	HTTP2HeaderTableField[] expected = [
+		HTTP2HeaderTableField(":method", HTTPMethod.GET),
+		HTTP2HeaderTableField(":scheme", "http"),
+		HTTP2HeaderTableField(":path", "/"),
+		HTTP2HeaderTableField(":authority", "www.example.com"),
+		HTTP2HeaderTableField("cache-control", "no-cache")];
+
+	foreach(i,h; decR1.data.enumerate(0)) {
+		assert(h == expected[i]);
+	}
+
+	/** 5. Full request with huffman encoding
+	  * :method: GET
+	  * :scheme: http
+	  * :path: /
+	  * :authority: www.example.com
+	  * cache-control: no-cache
+	  */
+	block = [0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c,0xbf];
+	auto decR2 = appender!(HTTP2HeaderTableField[]);
+	block.decodeHPACK(decR2, table);
+
+	foreach(i,h; decR2.data.enumerate(0)) {
+		assert(h == expected[i]);
+	}
+}

--- a/source/hpack/huffman.d
+++ b/source/hpack/huffman.d
@@ -79,7 +79,7 @@ private void decodeSymbol(O)(ref O decoded, ref char state, int pos, ref char eo
 	assert(entry.next != state, "Invalid symbol");
 
 	if (entry.emit) { // if the symbol is terminal
-		char sym = entry.symbol;
+		auto sym = cast(immutable(char))entry.symbol;
 		decoded.put(sym);
 	}
 
@@ -105,7 +105,6 @@ unittest {
 	import vibe.internal.array : BatchBuffer;
 
 	immutable ubyte[12] src = [0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff];
-	//BatchBuffer!char bres;
 	BatchBuffer!(char, 15) bres;
 	bres.putN(15);
 	decodeHuffman(src, bres);

--- a/source/hpack/huffman.d
+++ b/source/hpack/huffman.d
@@ -68,7 +68,7 @@ void decodeHuffman(I, O)(I source, ref O dst) @safe
 		decodeSymbol(dst, state, ch & 0xf, eos);
 	}
 
-	assert(eos, "Invalid dst string");
+	assert(eos, "Invalid encoded source");
 }
 
 private void decodeSymbol(O)(ref O decoded, ref char state, int pos, ref char eos)


### PR DESCRIPTION
The only issue towards a complete `nogc` compatibility is the `decodeLiteral` method in `decoder.d` which needs to allocate a buffer in case the `huffman` flag is found to be true.

A solution could be to consider a maximum length of the encoded string to be:
`(number of octets of encoded data) * 2` 
since huffman encoding allows for a compression ratio of at most `0.5`.

That said, I didn't want to allocate the buffer using `malloc` but to wait until the library is included in `vibe-http` to use vibe's allocators, so I left an `appender` with reserved capacity of `2*len` as above for now.